### PR TITLE
Fix #17: Change build settings to create fat jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,11 @@ jar {
     manifest {
         attributes 'Main-Class': 'CIServer'
     }
+
+    from {
+        configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
 }
 
 javadoc {


### PR DESCRIPTION
This includes the dependencies in the compiled jar, such that it can be run without linking them manually