### PR TITLE
Resolves #30: Changes to not be dependent on commit array

### DIFF
--- a/src/main/java/BuildRequestServlet.java
+++ b/src/main/java/BuildRequestServlet.java
@@ -60,12 +60,11 @@ public class BuildRequestServlet extends HttpServlet {
             JSONObject repo = reqObject.getJSONObject("repository");
             String url = repo.getString("html_url");      
             String cloneUrl = repo.getString("clone_url");
-            String statusesUrl = repo.getString("statuses_url");    
-            JSONArray commitArray = reqObject.getJSONArray("commits");
-            String idSHA = commitArray.getJSONObject(0).getString("id");
-            String nameAuthor = commitArray.getJSONObject(0).getJSONObject("author").getString("name");
-            String emailAuthor = commitArray.getJSONObject(0).getJSONObject("author").getString("email");
-            String timeStamp = commitArray.getJSONObject(0).getString("timestamp");
+            String statusesUrl = repo.getString("statuses_url");  
+            String nameAuthor = repo.getJSONObject("pusher").getString("name");
+            String emailAuthor = repo.getJSONObject("pusher").getString("email");  
+            String timeStamp = repo.getString("pushed_at");
+            String idSHA = reqObject.getJSONObject("head_commit").getString("id");
 
             return new Build(branchRef,nameAuthor,emailAuthor,idSHA,url,timeStamp,cloneUrl,statusesUrl);
         }catch (JSONException e) {

--- a/src/test/java/BuildRequestServletTests.java
+++ b/src/test/java/BuildRequestServletTests.java
@@ -15,20 +15,18 @@ public class BuildRequestServletTests {
 
     final String correctJson = "{\n" +
             "  \"ref\": \"refs/heads/testBranchName\",\n" +
-            "  \"commits\": [\n" +
-            "   {\n" +
+            "  \"head_commit\": {\n" +
             "    \"id\": \"abc123\",\n" +
-            "    \"timestamp\": \"20210207\",\n" +
-            "    \"author\": {\n" +
-            "      \"name\": \"AuthorName\",\n" +
-            "       \"email\": \"AuthorName@mail.com\",\n" +
-            "    },\n" +
             " },\n" +
-            "  ],\n" +
             "  \"repository\": {\n" +
             "    \"html_url\": \"https://github.com/Test/testRepoName.git\",\n" +
             "    \"clone_url\": \"https://github.com/Test/testRepoName.git\",\n" +
             "    \"statuses_url\": \"https://github.com/Test/testRepoName.git/statuses/{sha}\",\n" +
+            "    \"pushed_at\": \"20210207\",\n" +
+            "    \"pusher\": {\n" +
+            "      \"name\": \"AuthorName\",\n" +
+            "       \"email\": \"AuthorName@mail.com\",\n" +
+            "    },\n" +
             "  },\n" +
             "}";
 


### PR DESCRIPTION
Changed all so that nothing is dependent on the `commit array` in payload
* name and email is now dependent on the `pusher` 
* idSHA is now the one of the latest commit `head_commit`
* timeStamp is dependent on the time when it was pushed `pushed_at`

Tests were updated to fit the new Json format